### PR TITLE
Переместил $propertiesList после createOrderShipment/createOrderPayment

### DIFF
--- a/install/components/opensource/order/class.php
+++ b/install/components/opensource/order/class.php
@@ -374,17 +374,17 @@ class OpenSourceOrderComponent extends CBitrixComponent
         try {
             $this->createVirtualOrder($this->arParams['PERSON_TYPE_ID']);
 
-            $propertiesList = $this->request['properties'] ?? $this->arParams['DEFAULT_PROPERTIES'] ?? [];
-            if (!empty($propertiesList)) {
-                $this->setOrderProperties($propertiesList);
-            }
-
             $deliveryId = $this->request['delivery_id'] ?? $this->arParams['DEFAULT_DELIVERY_ID'] ?? 0;
             $this->createOrderShipment($deliveryId);
 
             $paySystemId = $this->request['pay_system_id'] ?? $this->arParams['DEFAULT_PAY_SYSTEM_ID'] ?? 0;
             if ($paySystemId > 0) {
                 $this->createOrderPayment($paySystemId);
+            }
+
+            $propertiesList = $this->request['properties'] ?? $this->arParams['DEFAULT_PROPERTIES'] ?? [];
+            if (!empty($propertiesList)) {
+                $this->setOrderProperties($propertiesList);
             }
 
             if ($this->arParams['SAVE']) {


### PR DESCRIPTION
Если свойства имеют какие-либо привязки - доставка/оплата, то их значения не сохраняются в форме.